### PR TITLE
feat: add delivery_person and order details fields to delivery resource, deny access to bot users

### DIFF
--- a/docs/modules/developer/nav.adoc
+++ b/docs/modules/developer/nav.adoc
@@ -1,3 +1,4 @@
 .Developer Docs
 * xref:dev_environment.adoc[]
 * xref:extensions.adoc[]
+* xref:test_plan.adoc[]

--- a/docs/modules/developer/pages/test_plan.adoc
+++ b/docs/modules/developer/pages/test_plan.adoc
@@ -1,0 +1,33 @@
+= 🔭 Test plan
+
+== Initialize a new delivery
+
+- Go to the following URL to open the create delivery form page:
+http://example.com/deliveries/new (The domain should be changed to the one where Tololo is hosted in)
+- Fill the details of the delivery through the form.
+
+== Change the state from `Init` to `Ready to pickup`
+
+- Click on the "Edit delivery" button.
+- Change state to "In preparation", then save.
+- Click on the "Edit delivery" button again.
+- Change state to "Ready to pickup", then save.
+
+== Authenticate Telegram user
+
+- The delivery person should send a message to the Tololo Telegram bot. The content of the message can be anything.
+- An access request will be sent to Tololo, then an admin will have to approve the user through the admin dashboard. The admin dashboard is in the following page: http://example.com/admin 
+The default user is `admin`, and the default password is `test`.
+- In the dashboard, click the `Users` dropdown menu at the top of the page, then select `User`. Then, select `Read` to see a list of the users that the bot has interacted with.
+- Find the user you wish to approve, then click on the pencil button. In the following page, change the `status` field from `pending` to `allowed`.
+- Click the `Save` button.
+
+== Pick delivery up through Telegram bot
+
+- Get the delivery public token. It will be shown in the delivery details page, after initializing the new delivery.
+- Send the following command to the Telegram bot: `/new {public token}`.
+- Share live location with bot.
+
+== Mark delivery as done after delivering
+
+- Send the `/done` command, then select the option with the previous public token.

--- a/tololo/core/lib/deliveries/delivery.ex
+++ b/tololo/core/lib/deliveries/delivery.ex
@@ -89,6 +89,7 @@ defmodule TololoCore.Deliveries.Delivery do
       action: :update_location
 
     define :get_ready_to_pickup
+    define :update_delivery_person
   end
 
   actions do
@@ -177,6 +178,10 @@ defmodule TololoCore.Deliveries.Delivery do
       require_atomic? false
 
       change TololoCore.Deliveries.UpdateHistory
+    end
+
+    update :update_delivery_person do
+      accept [:delivery_person]
     end
 
     update :update_location do

--- a/tololo/extensions/telegram_bot/lib/telegram/chains/auth.ex
+++ b/tololo/extensions/telegram_bot/lib/telegram/chains/auth.ex
@@ -11,6 +11,9 @@ defmodule Tololo.Extensions.TelegramBot.Auth do
   def handle(%{message: message, edited_message: nil}, context), do: handle(message, context)
   @impl true
   def handle(%{edited_message: message, message: nil}, context), do: handle(message, context)
+  @impl true
+  def handle(%{from: %{is_bot: true, id: user_id}}, context),
+    do: {:done, send_denied_message(context, user_id)}
 
   @impl true
   def handle(%{from: %{id: user_id}}, context) do

--- a/tololo/extensions/telegram_bot/lib/telegram/chains/set_token.ex
+++ b/tololo/extensions/telegram_bot/lib/telegram/chains/set_token.ex
@@ -25,7 +25,7 @@ defmodule Tololo.Extensions.TelegramBot.SetToken do
   def match?(_message, _context), do: false
 
   @impl true
-  def handle(%{from: %{id: user_id}, text: "#{@command} " <> token}, context) do
+  def handle(%{from: %{id: user_id} = from, text: "#{@command} " <> token}, context) do
     case Deliveries.Delivery.get_via_display_id(token, actor: @actor) do
       {:ok, %{state: state} = delivery_resource}
       when state == "Ready_To_Pickup" or state == "In_Delivery" ->
@@ -36,6 +36,7 @@ defmodule Tololo.Extensions.TelegramBot.SetToken do
           else
             delivery_resource
           end
+          |> update_delivery_person(from)
 
         context.user_resource |> User.add_deliveries!([delivery_resource.id], actor: @actor)
 
@@ -88,4 +89,23 @@ defmodule Tololo.Extensions.TelegramBot.SetToken do
 
     %{context | payload: send_message}
   end
+
+  defp update_delivery_person(delivery_resource, from),
+    do:
+      delivery_resource
+      |> Deliveries.Delivery.update_delivery_person!(
+        %{
+          delivery_person: %{
+            type: "telegram",
+            data: %{
+              name: from.first_name <> " " <> (from.last_name || ""),
+              user_id: from.id,
+              user_handle: from.username,
+              image: nil,
+              phone: nil
+            }
+          }
+        },
+        actor: @actor
+      )
 end

--- a/tololo/lib/tololo_web/live/delivery_live/form_component.ex
+++ b/tololo/lib/tololo_web/live/delivery_live/form_component.ex
@@ -154,10 +154,11 @@ defmodule TololoWeb.DeliveryLive.FormComponent do
             label={gettext("Address")}
           />
           <.input field={@form[:to_phone]} type="text" label={gettext("Phone")} />
+          <input name="delivery[delivery_order][type]" value="text" hidden readonly/>
           <.input
             type="map"
-            name="delivery_order"
-            fields={[{"name", gettext("Name")}]}
+            name="delivery[delivery_order]"
+            fields={[{"data", gettext("Description")}]}
             value={@form[:delivery_order].value}
             label={gettext("Order details")}
           />

--- a/tololo/priv/gettext/default.pot
+++ b/tololo/priv/gettext/default.pot
@@ -81,13 +81,12 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/form_component.ex:23
 #: lib/tololo_web/live/delivery_live/form_component.ex:36
 #: lib/tololo_web/live/delivery_live/form_component.ex:147
-#: lib/tololo_web/live/delivery_live/form_component.ex:160
 #, elixir-autogen, icu-format
 msgid "Name"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:40
-#: lib/tololo_web/live/delivery_live/form_component.ex:164
+#: lib/tololo_web/live/delivery_live/form_component.ex:165
 #, elixir-autogen, icu-format
 msgid "Notes"
 msgstr ""
@@ -99,19 +98,19 @@ msgid "Phone"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:55
-#: lib/tololo_web/live/delivery_live/form_component.ex:179
+#: lib/tololo_web/live/delivery_live/form_component.ex:180
 #, elixir-autogen, icu-format
 msgid "Save delivery"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:52
-#: lib/tololo_web/live/delivery_live/form_component.ex:176
+#: lib/tololo_web/live/delivery_live/form_component.ex:177
 #, elixir-autogen, icu-format
 msgid "Saving..."
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:46
-#: lib/tololo_web/live/delivery_live/form_component.ex:170
+#: lib/tololo_web/live/delivery_live/form_component.ex:171
 #: lib/tololo_web/live/delivery_live/index.ex:25
 #: lib/tololo_web/live/delivery_live/show.ex:23
 #, elixir-autogen, icu-format
@@ -119,7 +118,7 @@ msgid "State"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:54
-#: lib/tololo_web/live/delivery_live/form_component.ex:178
+#: lib/tololo_web/live/delivery_live/form_component.ex:179
 #, elixir-autogen, icu-format
 msgid "Update delivery"
 msgstr ""
@@ -267,7 +266,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/tololo_web/live/delivery_live/form_component.ex:162
+#: lib/tololo_web/live/delivery_live/form_component.ex:163
 #, elixir-autogen, icu-format
 msgid "Order details"
 msgstr ""
@@ -280,4 +279,9 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/location_input_component.ex:21
 #, elixir-autogen, icu-format
 msgid "Found address will show up here"
+msgstr ""
+
+#: lib/tololo_web/live/delivery_live/form_component.ex:161
+#, elixir-autogen, icu-format
+msgid "Description"
 msgstr ""

--- a/tololo/priv/gettext/en/LC_MESSAGES/default.po
+++ b/tololo/priv/gettext/en/LC_MESSAGES/default.po
@@ -81,13 +81,12 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/form_component.ex:23
 #: lib/tololo_web/live/delivery_live/form_component.ex:36
 #: lib/tololo_web/live/delivery_live/form_component.ex:147
-#: lib/tololo_web/live/delivery_live/form_component.ex:160
 #, elixir-autogen, icu-format
 msgid "Name"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:40
-#: lib/tololo_web/live/delivery_live/form_component.ex:164
+#: lib/tololo_web/live/delivery_live/form_component.ex:165
 #, elixir-autogen, icu-format
 msgid "Notes"
 msgstr ""
@@ -99,19 +98,19 @@ msgid "Phone"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:55
-#: lib/tololo_web/live/delivery_live/form_component.ex:179
+#: lib/tololo_web/live/delivery_live/form_component.ex:180
 #, elixir-autogen, icu-format
 msgid "Save delivery"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:52
-#: lib/tololo_web/live/delivery_live/form_component.ex:176
+#: lib/tololo_web/live/delivery_live/form_component.ex:177
 #, elixir-autogen, icu-format
 msgid "Saving..."
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:46
-#: lib/tololo_web/live/delivery_live/form_component.ex:170
+#: lib/tololo_web/live/delivery_live/form_component.ex:171
 #: lib/tololo_web/live/delivery_live/index.ex:25
 #: lib/tololo_web/live/delivery_live/show.ex:23
 #, elixir-autogen, icu-format
@@ -119,7 +118,7 @@ msgid "State"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:54
-#: lib/tololo_web/live/delivery_live/form_component.ex:178
+#: lib/tololo_web/live/delivery_live/form_component.ex:179
 #, elixir-autogen, icu-format
 msgid "Update delivery"
 msgstr ""
@@ -267,7 +266,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/tololo_web/live/delivery_live/form_component.ex:162
+#: lib/tololo_web/live/delivery_live/form_component.ex:163
 #, elixir-autogen, icu-format
 msgid "Order details"
 msgstr ""
@@ -280,4 +279,9 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/location_input_component.ex:21
 #, elixir-autogen, icu-format
 msgid "Found address will show up here"
+msgstr ""
+
+#: lib/tololo_web/live/delivery_live/form_component.ex:161
+#, elixir-autogen, icu-format
+msgid "Description"
 msgstr ""

--- a/tololo/priv/gettext/es/LC_MESSAGES/default.po
+++ b/tololo/priv/gettext/es/LC_MESSAGES/default.po
@@ -81,13 +81,12 @@ msgstr "Dirección"
 #: lib/tololo_web/live/delivery_live/form_component.ex:23
 #: lib/tololo_web/live/delivery_live/form_component.ex:36
 #: lib/tololo_web/live/delivery_live/form_component.ex:147
-#: lib/tololo_web/live/delivery_live/form_component.ex:160
 #, elixir-autogen, icu-format
 msgid "Name"
 msgstr "Nombre"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:40
-#: lib/tololo_web/live/delivery_live/form_component.ex:164
+#: lib/tololo_web/live/delivery_live/form_component.ex:165
 #, elixir-autogen, icu-format
 msgid "Notes"
 msgstr "Notas"
@@ -99,19 +98,19 @@ msgid "Phone"
 msgstr "Teléfono"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:55
-#: lib/tololo_web/live/delivery_live/form_component.ex:179
+#: lib/tololo_web/live/delivery_live/form_component.ex:180
 #, elixir-autogen, icu-format
 msgid "Save delivery"
 msgstr "Guardar delivery"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:52
-#: lib/tololo_web/live/delivery_live/form_component.ex:176
+#: lib/tololo_web/live/delivery_live/form_component.ex:177
 #, elixir-autogen, icu-format
 msgid "Saving..."
 msgstr "Guardando..."
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:46
-#: lib/tololo_web/live/delivery_live/form_component.ex:170
+#: lib/tololo_web/live/delivery_live/form_component.ex:171
 #: lib/tololo_web/live/delivery_live/index.ex:25
 #: lib/tololo_web/live/delivery_live/show.ex:23
 #, elixir-autogen, icu-format
@@ -119,7 +118,7 @@ msgid "State"
 msgstr "Estado"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:54
-#: lib/tololo_web/live/delivery_live/form_component.ex:178
+#: lib/tololo_web/live/delivery_live/form_component.ex:179
 #, elixir-autogen, icu-format
 msgid "Update delivery"
 msgstr "Actualizar delivery"
@@ -267,7 +266,7 @@ msgstr "Teléfono destino"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: lib/tololo_web/live/delivery_live/form_component.ex:162
+#: lib/tololo_web/live/delivery_live/form_component.ex:163
 #, elixir-autogen, icu-format
 msgid "Order details"
 msgstr "Detalles de la orden"
@@ -281,3 +280,8 @@ msgstr "Orden del delivery"
 #, elixir-autogen, icu-format
 msgid "Found address will show up here"
 msgstr "La dirección encontrada va a aparecer aqui"
+
+#: lib/tololo_web/live/delivery_live/form_component.ex:161
+#, elixir-autogen, icu-format
+msgid "Description"
+msgstr "Descripción"


### PR DESCRIPTION
- delivery_person is updated when picking up a delivery from Telegram bot
- order_details is added through new Delivery form
- bot users won't be able to interact with the Telegram bot