### PR TITLE
feat: add delivery_person and order details fields to delivery resource, deny access to bot users

### DIFF
--- a/tololo/core/lib/deliveries/delivery.ex
+++ b/tololo/core/lib/deliveries/delivery.ex
@@ -89,6 +89,7 @@ defmodule TololoCore.Deliveries.Delivery do
       action: :update_location
 
     define :get_ready_to_pickup
+    define :update_delivery_person
   end
 
   actions do
@@ -177,6 +178,10 @@ defmodule TololoCore.Deliveries.Delivery do
       require_atomic? false
 
       change TololoCore.Deliveries.UpdateHistory
+    end
+
+    update :update_delivery_person do
+      accept [:delivery_person]
     end
 
     update :update_location do

--- a/tololo/extensions/telegram_bot/lib/telegram/chains/auth.ex
+++ b/tololo/extensions/telegram_bot/lib/telegram/chains/auth.ex
@@ -11,6 +11,9 @@ defmodule Tololo.Extensions.TelegramBot.Auth do
   def handle(%{message: message, edited_message: nil}, context), do: handle(message, context)
   @impl true
   def handle(%{edited_message: message, message: nil}, context), do: handle(message, context)
+  @impl true
+  def handle(%{from: %{is_bot: true, id: user_id}}, context),
+    do: {:done, send_denied_message(context, user_id)}
 
   @impl true
   def handle(%{from: %{id: user_id}}, context) do

--- a/tololo/extensions/telegram_bot/lib/telegram/chains/set_token.ex
+++ b/tololo/extensions/telegram_bot/lib/telegram/chains/set_token.ex
@@ -25,7 +25,7 @@ defmodule Tololo.Extensions.TelegramBot.SetToken do
   def match?(_message, _context), do: false
 
   @impl true
-  def handle(%{from: %{id: user_id}, text: "#{@command} " <> token}, context) do
+  def handle(%{from: %{id: user_id} = from, text: "#{@command} " <> token}, context) do
     case Deliveries.Delivery.get_via_display_id(token, actor: @actor) do
       {:ok, %{state: state} = delivery_resource}
       when state == "Ready_To_Pickup" or state == "In_Delivery" ->
@@ -36,6 +36,7 @@ defmodule Tololo.Extensions.TelegramBot.SetToken do
           else
             delivery_resource
           end
+          |> update_delivery_person(from)
 
         context.user_resource |> User.add_deliveries!([delivery_resource.id], actor: @actor)
 
@@ -88,4 +89,24 @@ defmodule Tololo.Extensions.TelegramBot.SetToken do
 
     %{context | payload: send_message}
   end
+
+  defp update_delivery_person(delivery_resource, from),
+    do:
+      delivery_resource
+      |> Deliveries.Delivery.update_delivery_person!(
+        %{
+          delivery_person: %{
+            type: "telegram",
+            data: %{
+              name:
+                (from.first_name || gettext("Delivery Person")) <> " " <> (from.last_name || ""),
+              user_id: from.id,
+              user_handle: from.username,
+              image: nil,
+              phone: nil
+            }
+          }
+        },
+        actor: @actor
+      )
 end

--- a/tololo/extensions/telegram_bot/priv/gettext/default.pot
+++ b/tololo/extensions/telegram_bot/priv/gettext/default.pot
@@ -31,7 +31,7 @@ msgstr ""
 msgid "No active deliveries found. Please start one by using `/new {token}`."
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:54
+#: lib/telegram/chains/set_token.ex:55
 #, elixir-autogen, icu-format
 msgid "Please include the provided token with the command:\n\n`/new {token}`\n"
 msgstr ""
@@ -41,52 +41,57 @@ msgstr ""
 msgid "Thanks for using Tololo Bot. An Admin will contact you soon.\n"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:84
+#: lib/telegram/chains/set_token.ex:85
 #, elixir-autogen, icu-format
 msgid "There was a problem. Please check that the token is valid.\n"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:68
+#: lib/telegram/chains/set_token.ex:69
 #, elixir-autogen, icu-format
 msgid "delivery_info"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:73
+#: lib/telegram/chains/set_token.ex:74
 #, elixir-autogen, icu-format
 msgid "No additional notes"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:72
+#: lib/telegram/chains/set_token.ex:73
 #, elixir-autogen, icu-format
 msgid "No address provided"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:71
+#: lib/telegram/chains/set_token.ex:72
 #, elixir-autogen, icu-format
 msgid "No phone number provided"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:70
+#: lib/telegram/chains/set_token.ex:71
 #, elixir-autogen, icu-format
 msgid "Unknown person"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:81
+#: lib/telegram/chains/done.ex:82
 #, elixir-autogen, icu-format
 msgid "*Hello*\n\nPlease select the delivery you wish to mark as done\n"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:45
+#: lib/telegram/chains/done.ex:46
 #, elixir-autogen, icu-format
 msgid "Delivery successfully marked as done.\n"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:36
+#: lib/telegram/chains/done.ex:35
 #, elixir-autogen, icu-format
 msgid "Delivery wasn't found.\n"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:50
+#: lib/telegram/chains/done.ex:51
 #, elixir-autogen, icu-format
 msgid "There was a problem marking delivery as done\n"
+msgstr ""
+
+#: lib/telegram/chains/set_token.ex:102
+#, elixir-autogen, icu-format
+msgid "Delivery Person"
 msgstr ""

--- a/tololo/extensions/telegram_bot/priv/gettext/en/LC_MESSAGES/default.po
+++ b/tololo/extensions/telegram_bot/priv/gettext/en/LC_MESSAGES/default.po
@@ -31,7 +31,7 @@ msgstr ""
 msgid "No active deliveries found. Please start one by using `/new {token}`."
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:54
+#: lib/telegram/chains/set_token.ex:55
 #, elixir-autogen, icu-format
 msgid "Please include the provided token with the command:\n\n`/new {token}`\n"
 msgstr ""
@@ -41,52 +41,57 @@ msgstr ""
 msgid "Thanks for using Tololo Bot. An Admin will contact you soon.\n"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:84
+#: lib/telegram/chains/set_token.ex:85
 #, elixir-autogen, icu-format
 msgid "There was a problem. Please check that the token is valid.\n"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:68
+#: lib/telegram/chains/set_token.ex:69
 #, elixir-autogen, icu-format
 msgid "delivery_info"
 msgstr "*This is the delivery information:*\n- Name: {name}\n- Phone: {phone}\n- Address: {address}\n- Details: {details}\n*Great! Now please send the live location for at least one hour.*"
 
-#: lib/telegram/chains/set_token.ex:73
+#: lib/telegram/chains/set_token.ex:74
 #, elixir-autogen, icu-format
 msgid "No additional notes"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:72
+#: lib/telegram/chains/set_token.ex:73
 #, elixir-autogen, icu-format
 msgid "No address provided"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:71
+#: lib/telegram/chains/set_token.ex:72
 #, elixir-autogen, icu-format
 msgid "No phone number provided"
 msgstr ""
 
-#: lib/telegram/chains/set_token.ex:70
+#: lib/telegram/chains/set_token.ex:71
 #, elixir-autogen, icu-format
 msgid "Unknown person"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:81
+#: lib/telegram/chains/done.ex:82
 #, elixir-autogen, icu-format, fuzzy
 msgid "*Hello*\n\nPlease select the delivery you wish to mark as done\n"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:45
+#: lib/telegram/chains/done.ex:46
 #, elixir-autogen, icu-format
 msgid "Delivery successfully marked as done.\n"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:36
+#: lib/telegram/chains/done.ex:35
 #, elixir-autogen, icu-format
 msgid "Delivery wasn't found.\n"
 msgstr ""
 
-#: lib/telegram/chains/done.ex:50
+#: lib/telegram/chains/done.ex:51
 #, elixir-autogen, icu-format
 msgid "There was a problem marking delivery as done\n"
+msgstr ""
+
+#: lib/telegram/chains/set_token.ex:102
+#, elixir-autogen, icu-format
+msgid "Delivery Person"
 msgstr ""

--- a/tololo/extensions/telegram_bot/priv/gettext/es/LC_MESSAGES/default.po
+++ b/tololo/extensions/telegram_bot/priv/gettext/es/LC_MESSAGES/default.po
@@ -31,7 +31,7 @@ msgstr "Error al intentar actualizar la ubicación."
 msgid "No active deliveries found. Please start one by using `/new {token}`."
 msgstr "No se encontraron entregas activas. Por favor, inicia una usando `/new {token}`."
 
-#: lib/telegram/chains/set_token.ex:54
+#: lib/telegram/chains/set_token.ex:55
 #, elixir-autogen, icu-format
 msgid "Please include the provided token with the command:\n\n`/new {token}`\n"
 msgstr "Por favor, incluye el token proporcionado con el comando:\n\n`/new {token}`\n"
@@ -41,52 +41,57 @@ msgstr "Por favor, incluye el token proporcionado con el comando:\n\n`/new {toke
 msgid "Thanks for using Tololo Bot. An Admin will contact you soon.\n"
 msgstr "Gracias por usar Tololo Bot. Un administrador se pondrá en contacto contigo pronto.\n"
 
-#: lib/telegram/chains/set_token.ex:84
+#: lib/telegram/chains/set_token.ex:85
 #, elixir-autogen, icu-format
 msgid "There was a problem. Please check that the token is valid.\n"
 msgstr "Hubo un problema. Por favor, verifica que el token sea válido.\n"
 
-#: lib/telegram/chains/set_token.ex:68
+#: lib/telegram/chains/set_token.ex:69
 #, elixir-autogen, icu-format
 msgid "delivery_info"
 msgstr "*Esta es la información del delivery:*\n- Nombre: {name}\n- Teléfono: {phone}\n- Dirección: {address}\n- Detalles: {details}\n*Bien! Ahora por favor envía tu ubicación por lo menos durante una hora.*"
 
-#: lib/telegram/chains/set_token.ex:73
+#: lib/telegram/chains/set_token.ex:74
 #, elixir-autogen, icu-format
 msgid "No additional notes"
 msgstr "No hay notas adicionales"
 
-#: lib/telegram/chains/set_token.ex:72
+#: lib/telegram/chains/set_token.ex:73
 #, elixir-autogen, icu-format
 msgid "No address provided"
 msgstr "No se proporcionó dirección"
 
-#: lib/telegram/chains/set_token.ex:71
+#: lib/telegram/chains/set_token.ex:72
 #, elixir-autogen, icu-format
 msgid "No phone number provided"
 msgstr "No se proporcionó número de teléfono"
 
-#: lib/telegram/chains/set_token.ex:70
+#: lib/telegram/chains/set_token.ex:71
 #, elixir-autogen, icu-format
 msgid "Unknown person"
 msgstr "Persona desconocida"
 
-#: lib/telegram/chains/done.ex:81
+#: lib/telegram/chains/done.ex:82
 #, elixir-autogen, icu-format, fuzzy
 msgid "*Hello*\n\nPlease select the delivery you wish to mark as done\n"
 msgstr "*Hola*\n\nPor favor, selecciona el delivery que deseas recoger\n"
 
-#: lib/telegram/chains/done.ex:45
+#: lib/telegram/chains/done.ex:46
 #, elixir-autogen, icu-format
 msgid "Delivery successfully marked as done.\n"
 msgstr "El delivery fue marcado como terminado exitosamente"
 
-#: lib/telegram/chains/done.ex:36
+#: lib/telegram/chains/done.ex:35
 #, elixir-autogen, icu-format
 msgid "Delivery wasn't found.\n"
 msgstr "Delivery no encontrado.\n"
 
-#: lib/telegram/chains/done.ex:50
+#: lib/telegram/chains/done.ex:51
 #, elixir-autogen, icu-format
 msgid "There was a problem marking delivery as done\n"
 msgstr "Hubo un problema marcando el delivery como terminado.\n"
+
+#: lib/telegram/chains/set_token.ex:102
+#, elixir-autogen, icu-format
+msgid "Delivery Person"
+msgstr "Repartidor"

--- a/tololo/lib/tololo_web/live/delivery_live/form_component.ex
+++ b/tololo/lib/tololo_web/live/delivery_live/form_component.ex
@@ -154,10 +154,11 @@ defmodule TololoWeb.DeliveryLive.FormComponent do
             label={gettext("Address")}
           />
           <.input field={@form[:to_phone]} type="text" label={gettext("Phone")} />
+          <input name="delivery[delivery_order][type]" value="text" hidden readonly/>
           <.input
             type="map"
-            name="delivery_order"
-            fields={[{"name", gettext("Name")}]}
+            name="delivery[delivery_order]"
+            fields={[{"data", gettext("Description")}]}
             value={@form[:delivery_order].value}
             label={gettext("Order details")}
           />

--- a/tololo/priv/gettext/default.pot
+++ b/tololo/priv/gettext/default.pot
@@ -81,13 +81,12 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/form_component.ex:23
 #: lib/tololo_web/live/delivery_live/form_component.ex:36
 #: lib/tololo_web/live/delivery_live/form_component.ex:147
-#: lib/tololo_web/live/delivery_live/form_component.ex:160
 #, elixir-autogen, icu-format
 msgid "Name"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:40
-#: lib/tololo_web/live/delivery_live/form_component.ex:164
+#: lib/tololo_web/live/delivery_live/form_component.ex:165
 #, elixir-autogen, icu-format
 msgid "Notes"
 msgstr ""
@@ -99,19 +98,19 @@ msgid "Phone"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:55
-#: lib/tololo_web/live/delivery_live/form_component.ex:179
+#: lib/tololo_web/live/delivery_live/form_component.ex:180
 #, elixir-autogen, icu-format
 msgid "Save delivery"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:52
-#: lib/tololo_web/live/delivery_live/form_component.ex:176
+#: lib/tololo_web/live/delivery_live/form_component.ex:177
 #, elixir-autogen, icu-format
 msgid "Saving..."
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:46
-#: lib/tololo_web/live/delivery_live/form_component.ex:170
+#: lib/tololo_web/live/delivery_live/form_component.ex:171
 #: lib/tololo_web/live/delivery_live/index.ex:25
 #: lib/tololo_web/live/delivery_live/show.ex:23
 #, elixir-autogen, icu-format
@@ -119,7 +118,7 @@ msgid "State"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:54
-#: lib/tololo_web/live/delivery_live/form_component.ex:178
+#: lib/tololo_web/live/delivery_live/form_component.ex:179
 #, elixir-autogen, icu-format
 msgid "Update delivery"
 msgstr ""
@@ -267,7 +266,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/tololo_web/live/delivery_live/form_component.ex:162
+#: lib/tololo_web/live/delivery_live/form_component.ex:163
 #, elixir-autogen, icu-format
 msgid "Order details"
 msgstr ""
@@ -280,4 +279,9 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/location_input_component.ex:21
 #, elixir-autogen, icu-format
 msgid "Found address will show up here"
+msgstr ""
+
+#: lib/tololo_web/live/delivery_live/form_component.ex:161
+#, elixir-autogen, icu-format
+msgid "Description"
 msgstr ""

--- a/tololo/priv/gettext/en/LC_MESSAGES/default.po
+++ b/tololo/priv/gettext/en/LC_MESSAGES/default.po
@@ -81,13 +81,12 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/form_component.ex:23
 #: lib/tololo_web/live/delivery_live/form_component.ex:36
 #: lib/tololo_web/live/delivery_live/form_component.ex:147
-#: lib/tololo_web/live/delivery_live/form_component.ex:160
 #, elixir-autogen, icu-format
 msgid "Name"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:40
-#: lib/tololo_web/live/delivery_live/form_component.ex:164
+#: lib/tololo_web/live/delivery_live/form_component.ex:165
 #, elixir-autogen, icu-format
 msgid "Notes"
 msgstr ""
@@ -99,19 +98,19 @@ msgid "Phone"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:55
-#: lib/tololo_web/live/delivery_live/form_component.ex:179
+#: lib/tololo_web/live/delivery_live/form_component.ex:180
 #, elixir-autogen, icu-format
 msgid "Save delivery"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:52
-#: lib/tololo_web/live/delivery_live/form_component.ex:176
+#: lib/tololo_web/live/delivery_live/form_component.ex:177
 #, elixir-autogen, icu-format
 msgid "Saving..."
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:46
-#: lib/tololo_web/live/delivery_live/form_component.ex:170
+#: lib/tololo_web/live/delivery_live/form_component.ex:171
 #: lib/tololo_web/live/delivery_live/index.ex:25
 #: lib/tololo_web/live/delivery_live/show.ex:23
 #, elixir-autogen, icu-format
@@ -119,7 +118,7 @@ msgid "State"
 msgstr ""
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:54
-#: lib/tololo_web/live/delivery_live/form_component.ex:178
+#: lib/tololo_web/live/delivery_live/form_component.ex:179
 #, elixir-autogen, icu-format
 msgid "Update delivery"
 msgstr ""
@@ -267,7 +266,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/tololo_web/live/delivery_live/form_component.ex:162
+#: lib/tololo_web/live/delivery_live/form_component.ex:163
 #, elixir-autogen, icu-format
 msgid "Order details"
 msgstr ""
@@ -280,4 +279,9 @@ msgstr ""
 #: lib/tololo_web/live/delivery_live/location_input_component.ex:21
 #, elixir-autogen, icu-format
 msgid "Found address will show up here"
+msgstr ""
+
+#: lib/tololo_web/live/delivery_live/form_component.ex:161
+#, elixir-autogen, icu-format
+msgid "Description"
 msgstr ""

--- a/tololo/priv/gettext/es/LC_MESSAGES/default.po
+++ b/tololo/priv/gettext/es/LC_MESSAGES/default.po
@@ -81,13 +81,12 @@ msgstr "Dirección"
 #: lib/tololo_web/live/delivery_live/form_component.ex:23
 #: lib/tololo_web/live/delivery_live/form_component.ex:36
 #: lib/tololo_web/live/delivery_live/form_component.ex:147
-#: lib/tololo_web/live/delivery_live/form_component.ex:160
 #, elixir-autogen, icu-format
 msgid "Name"
 msgstr "Nombre"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:40
-#: lib/tololo_web/live/delivery_live/form_component.ex:164
+#: lib/tololo_web/live/delivery_live/form_component.ex:165
 #, elixir-autogen, icu-format
 msgid "Notes"
 msgstr "Notas"
@@ -99,19 +98,19 @@ msgid "Phone"
 msgstr "Teléfono"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:55
-#: lib/tololo_web/live/delivery_live/form_component.ex:179
+#: lib/tololo_web/live/delivery_live/form_component.ex:180
 #, elixir-autogen, icu-format
 msgid "Save delivery"
 msgstr "Guardar delivery"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:52
-#: lib/tololo_web/live/delivery_live/form_component.ex:176
+#: lib/tololo_web/live/delivery_live/form_component.ex:177
 #, elixir-autogen, icu-format
 msgid "Saving..."
 msgstr "Guardando..."
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:46
-#: lib/tololo_web/live/delivery_live/form_component.ex:170
+#: lib/tololo_web/live/delivery_live/form_component.ex:171
 #: lib/tololo_web/live/delivery_live/index.ex:25
 #: lib/tololo_web/live/delivery_live/show.ex:23
 #, elixir-autogen, icu-format
@@ -119,7 +118,7 @@ msgid "State"
 msgstr "Estado"
 
 #: lib/tololo_web/live/delivery_live/form_component.ex:54
-#: lib/tololo_web/live/delivery_live/form_component.ex:178
+#: lib/tololo_web/live/delivery_live/form_component.ex:179
 #, elixir-autogen, icu-format
 msgid "Update delivery"
 msgstr "Actualizar delivery"
@@ -267,7 +266,7 @@ msgstr "Teléfono destino"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: lib/tololo_web/live/delivery_live/form_component.ex:162
+#: lib/tololo_web/live/delivery_live/form_component.ex:163
 #, elixir-autogen, icu-format
 msgid "Order details"
 msgstr "Detalles de la orden"
@@ -281,3 +280,8 @@ msgstr "Orden del delivery"
 #, elixir-autogen, icu-format
 msgid "Found address will show up here"
 msgstr "La dirección encontrada va a aparecer aqui"
+
+#: lib/tololo_web/live/delivery_live/form_component.ex:161
+#, elixir-autogen, icu-format
+msgid "Description"
+msgstr "Descripción"


### PR DESCRIPTION
- delivery_person is updated when picking up a delivery from Telegram bot
- order_details is added through new Delivery form
- bot users won't be able to interact with the Telegram bot